### PR TITLE
Add missing 'new' keyword in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ use \Snaggle\Client\Header\Header;
 $consumer = new ConsumerCredentials();
 $consumer->setIdentifier('CONSUMER KEY');
 $consumer->setSecret('CONSUMER SECRET');
-$access = AccessCredentials();
+$access = new AccessCredentials();
 if (!isset($_GET['oauth_token']) && !isset($_GET['oauth_verifier'])) {
 
     $signature = new HmacSha1($consumer, $access);


### PR DESCRIPTION
I _think_ this is missing unless I'm misunderstanding something?
