### PR TITLE
Fix: Autoloading is all the bootstrapping required

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="tests/Bootstrap.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Snaggle">
             <directory>./tests</directory>

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,2 +1,0 @@
-<?php
-require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';


### PR DESCRIPTION
At least at the moment, so there's not really a need for a file that just includes Composer's autoloading file.