### PR TITLE
Fix: Composer comes pre-installed on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ php:
   - "5.4"
   - "5.5"
   - "5.6"
-before_script:
-  - composer install
+install: composer install
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ php:
   - "5.5"
   - "5.6"
 before_script:
-  - curl http://getcomposer.org/installer | php
-  - php composer.phar install
+  - composer install
 script: phpunit


### PR DESCRIPTION
This PR

* skips downloading Composer as it comes pre-installed with Travis (http://docs.travis-ci.com/user/languages/php/#Installing-Composer-packages)
* installs dependencies in the `install` section (http://docs.travis-ci.com/user/languages/php/#Dependency-Management-(a.k.a.-vendoring))