### PR TITLE
Fix: Require phpunit/phpunit as a dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ php:
 before_script:
   - curl http://getcomposer.org/installer | php
   - php composer.phar install
-script: phpunit
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
         "psr-0": {
             "Snaggle" : "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.4"
     }
 }


### PR DESCRIPTION
This PR 

* requires `phpunit/phpunit` as a `dev` dependency as it is an actual development dependency
* uses the required `phpunit` to run tests on Travis