### PR TITLE
Fix: Visibility of setUp() and tearDown() should be protected

### DIFF
--- a/tests/src/Client/Header/HeaderTest.php
+++ b/tests/src/Client/Header/HeaderTest.php
@@ -20,7 +20,7 @@ Class HeaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Set up - runs prior to each test
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->consumer = new ConsumerCredentials();
         $this->consumer->setIdentifier('CONSUMER');
@@ -37,7 +37,7 @@ Class HeaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down - runs after each test
      */
-    public function tearDown()
+    protected function tearDown()
     {
         unset($this->consumer);
         unset($this->user);

--- a/tests/src/Client/Signature/HmacSha1Test.php
+++ b/tests/src/Client/Signature/HmacSha1Test.php
@@ -17,7 +17,7 @@ class HmacSha1Test extends \PHPUnit_Framework_TestCase
     /**
      * Setup
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->consumer = new ConsumerCredentials();
         $this->consumer->setIdentifier('ABCDEFG');
@@ -32,7 +32,7 @@ class HmacSha1Test extends \PHPUnit_Framework_TestCase
     /**
      * Tear Down
      */
-    public function tearDown()
+    protected function tearDown()
     {
         unset($this->user);
         unset($this->consumer);

--- a/tests/src/Client/Signature/PlaintextTest.php
+++ b/tests/src/Client/Signature/PlaintextTest.php
@@ -17,7 +17,7 @@ class PlaintextTest extends \PHPUnit_Framework_TestCase
     /**
      * Setup
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->consumer = new ConsumerCredentials();
         $this->consumer->setIdentifier('ABCDEFG');
@@ -31,7 +31,7 @@ class PlaintextTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down
      */
-    public function tearDown()
+    protected function tearDown()
     {
         unset($this->consumer);
         unset($this->user);


### PR DESCRIPTION
This PR

* reduces the visibility of `setUp()` and `tearDown()` in tests to `protected`, as this is the visibility of these methods in the parent class