### PR TITLE
Fix: Do not declare fields dynamically

### DIFF
--- a/tests/src/Client/Header/HeaderTest.php
+++ b/tests/src/Client/Header/HeaderTest.php
@@ -18,6 +18,26 @@ use Snaggle\Client\Credentials\AccessCredentials;
 Class HeaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ConsumerCredentials
+     */
+    private $consumer;
+
+    /**
+     * @var AccessCredentials
+     */
+    private $user;
+
+    /**
+     * @var HmacSha1
+     */
+    private $signature;
+
+    /**
+     * @var Plaintext
+     */
+    private $plaintext;
+
+    /**
      * Set up - runs prior to each test
      */
     public function setUp()

--- a/tests/src/Client/Signature/HmacSha1Test.php
+++ b/tests/src/Client/Signature/HmacSha1Test.php
@@ -15,6 +15,21 @@ use Snaggle\Client\Credentials\AccessCredentials;
 class HmacSha1Test extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ConsumerCredentials
+     */
+    private $consumer;
+
+    /**
+     * @var AccessCredentials
+     */
+    private $user;
+
+    /**
+     * @var HmacSha1
+     */
+    private $signature;
+
+    /**
      * Setup
      */
     public function setUp()

--- a/tests/src/Client/Signature/PlaintextTest.php
+++ b/tests/src/Client/Signature/PlaintextTest.php
@@ -15,6 +15,16 @@ use Snaggle\Client\Credentials\ConsumerCredentials;
 class PlaintextTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ConsumerCredentials
+     */
+    private $consumer;
+
+    /**
+     * @var AccessCredentials
+     */
+    private $user;
+
+    /**
      * Setup
      */
     public function setUp()


### PR DESCRIPTION
Because friends don't let friends declare fields dynamically.