### PR TITLE
Fix: Run PHP_CodeSniffer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ php:
 before_script:
   - curl http://getcomposer.org/installer | php
   - php composer.phar install
-script: phpunit
+script:
+  - vendor/bin/phpcs --standard=PSR2 -p --ignore=vendor .
+  - phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
         "psr-0": {
             "Snaggle" : "src/"
         }
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "~2.1"
     }
 }

--- a/src/Snaggle/Client/Credentials/ConsumerCredentials.php
+++ b/src/Snaggle/Client/Credentials/ConsumerCredentials.php
@@ -9,7 +9,7 @@ namespace Snaggle\Client\Credentials;
  * @license http://opensource.org/licenses/MIT MIT
  *
  * A class to represent the credentials of the consuming service provider,
- * these are the credentials that are assigned when an API application 
+ * these are the credentials that are assigned when an API application
  * is created
  */
 class ConsumerCredentials implements CredentialInterface

--- a/src/Snaggle/Client/Credentials/CredentialInterface.php
+++ b/src/Snaggle/Client/Credentials/CredentialInterface.php
@@ -17,7 +17,7 @@ interface CredentialInterface
     /**
      * getIdentifier method to return the identifying value of the credential
      *
-     * @return string 
+     * @return string
      */
     public function getIdentifier();
 

--- a/src/Snaggle/Client/Credentials/RequestCredentials.php
+++ b/src/Snaggle/Client/Credentials/RequestCredentials.php
@@ -9,7 +9,7 @@ namespace Snaggle\Client\Credentials;
  * @license http://opensource.org/licenses/MIT MIT
  *
  * This will store the temporary credentials that are sent back in the first
- * step of the token exchange. These are short-lived credentials and will 
+ * step of the token exchange. These are short-lived credentials and will
  * expire if they aren't exchanged for Access Credentials
  */
 class RequestCredentials implements Credential

--- a/src/Snaggle/Client/Credentials/TemporaryCredentials.php
+++ b/src/Snaggle/Client/Credentials/TemporaryCredentials.php
@@ -15,7 +15,7 @@ class TemporaryCredentials
 {
     /**
      * The OAuth token that is provided after authorization
-     * 
+     *
      * @var string $identifier
      */
     private $identifier = '';

--- a/src/Snaggle/Client/Header/Header.php
+++ b/src/Snaggle/Client/Header/Header.php
@@ -1,5 +1,6 @@
 <?php
 namespace Snaggle\Client\Header;
+
 use \Snaggle\Client\Signatures\SignatureInterface;
 
 /**
@@ -25,7 +26,7 @@ class Header
      *
      * @return string
      */
-    public function createAuthorizationHeader($includePrefix=false)
+    public function createAuthorizationHeader($includePrefix = false)
     {
         $headerParams = array(
             'oauth_signature' => $this->signature->sign(),
@@ -47,7 +48,7 @@ class Header
         $tempArray = array();
         ksort($headerParams);
 
-        foreach($headerParams as $key => $value) {
+        foreach ($headerParams as $key => $value) {
             $tempArray[] = $key . '="' . rawurlencode($value) . '"';
         }
 

--- a/src/Snaggle/Client/Signatures/HmacSha1.php
+++ b/src/Snaggle/Client/Signatures/HmacSha1.php
@@ -71,10 +71,10 @@ class HmacSha1 extends Signature implements SignatureInterface
         foreach ($oauthParams as $key => $value) {
             $tempArray[] = $key . '=' . rawurlencode($value);
         }
-        $parsedResource = parse_url($this->resourceURL);
+        $parsedUrl = parse_url($this->resourceURL);
         $baseString = $this->httpMethod .'&';
-        $baseString .= rawurlencode($parsedResource['scheme'] . '://' . $parsedResource['host'] . $parsedResource['path']);
-        $baseString .= (isset($parsedResource['query'])) ? '&' . rawurlencode($parsedResource['query']) . '%26' : '&';
+        $baseString .= rawurlencode($parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path']);
+        $baseString .= (isset($parsedUrl['query'])) ? '&' . rawurlencode($parsedUrl['query']) . '%26' : '&';
         $baseString .= rawurlencode(implode('&', $tempArray));
         if (!empty($this->postFields)) {
             foreach ($this->postFields as $key => $value) {

--- a/src/Snaggle/Client/Signatures/HmacSha1.php
+++ b/src/Snaggle/Client/Signatures/HmacSha1.php
@@ -68,7 +68,7 @@ class HmacSha1 extends Signature implements SignatureInterface
             unset($oauthParams['oauth_verifier']);
         }
 
-        foreach($oauthParams as $key => $value) {
+        foreach ($oauthParams as $key => $value) {
             $tempArray[] = $key . '=' . rawurlencode($value);
         }
         $parsedResource = parse_url($this->resourceURL);
@@ -128,4 +128,3 @@ class HmacSha1 extends Signature implements SignatureInterface
         $this->include_empty_token = $value;
     }
 }
-

--- a/src/Snaggle/Client/Signatures/HmacSha1.php
+++ b/src/Snaggle/Client/Signatures/HmacSha1.php
@@ -81,7 +81,6 @@ class HmacSha1 extends Signature implements SignatureInterface
                 $baseString .= '%26' . $key .rawurlencode('=') . rawurlencode($value);
             }
         }
-        //return $this->httpMethod . '&' . rawurlencode($this->resourceURL) . '&' . rawurlencode(implode('&', $tempArray));
         return $baseString;
     }
 

--- a/src/Snaggle/Client/Signatures/Plaintext.php
+++ b/src/Snaggle/Client/Signatures/Plaintext.php
@@ -6,7 +6,7 @@ namespace Snaggle\Client\Signatures;
  * @license http://opensource.org/licenses/MIT MIT
  * @copyright (c) 2014
  * @package Snaggle
- * @subpackage Client 
+ * @subpackage Client
  *
  * Plaintext signature method for OAuth 1 clients, important to note
  * this should only be used when there is no other way to authenticate
@@ -28,5 +28,4 @@ class Plaintext extends Signature implements SignatureInterface
     {
         return rawurlencode($this->getConsumer()->getSecret()) . '&'. rawurlencode($this->getUser()->getSecret());
     }
-
 }

--- a/src/Snaggle/Client/Signatures/Signature.php
+++ b/src/Snaggle/Client/Signatures/Signature.php
@@ -8,14 +8,14 @@ namespace Snaggle\Client\Signatures;
  * @package Snaggle
  * @subpackage Client
  *
- * Base functionality for the signatures, including all the 
+ * Base functionality for the signatures, including all the
  * properties and accessor methods
  */
 class Signature
 {
     /**
      * Value for the nonce
-     *                   
+     *
      * @var string $nonce
      */
     protected $nonce = '';
@@ -97,13 +97,12 @@ class Signature
     public function __construct(
         \Snaggle\Client\Credentials\CredentialInterface $consumerCredential,
         \Snaggle\Client\Credentials\CredentialInterface $userCredential
-    )
-    {
+    ) {
         $this->consumerCredential = $consumerCredential;
         $this->userCredential = $userCredential;
     }
 
-   /**
+    /**
     * Method for retrieving HTTP Verb
     *
     * @return string
@@ -131,7 +130,7 @@ class Signature
             throw new \InvalidArgumentException('Provided method not allowed');
         }
         $this->httpMethod = strtoupper($method);
-		return $this;
+        return $this;
     }
 
     /**
@@ -278,7 +277,7 @@ class Signature
     }
 
     /**
-     * Method to set the POST FIELDS or data of a post request, this may be required in your 
+     * Method to set the POST FIELDS or data of a post request, this may be required in your
      * base string
      *
      * @param array $postFields

--- a/tests/src/Client/Header/HeaderTest.php
+++ b/tests/src/Client/Header/HeaderTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Snaggle\Client\Header;
+
 use Snaggle\Client\Signatures\HmacSha1;
 use Snaggle\Client\Signatures\Plaintext;
 use Snaggle\Client\Credentials\ConsumerCredentials;
 use Snaggle\Client\Credentials\AccessCredentials;
-
 
 /**
  * @author Matt Frost <mfrost.design@gmail.com>
@@ -15,7 +15,7 @@ use Snaggle\Client\Credentials\AccessCredentials;
  *
  * Tests for the header functionality
  */
-Class HeaderTest extends \PHPUnit_Framework_TestCase
+class HeaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Set up - runs prior to each test

--- a/tests/src/Client/Signature/HmacSha1Test.php
+++ b/tests/src/Client/Signature/HmacSha1Test.php
@@ -1,5 +1,6 @@
 <?php
 namespace Snaggle\Client\Signatures;
+
 use Snaggle\Client\Credentials\ConsumerCredentials;
 use Snaggle\Client\Credentials\AccessCredentials;
 
@@ -148,4 +149,3 @@ class HmacSha1Test extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($this->signature->sign(), 'The signature was empty');
     }
 }
-

--- a/tests/src/Client/Signature/PlaintextTest.php
+++ b/tests/src/Client/Signature/PlaintextTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Snaggle\Client\Signatures;
+
 use Snaggle\Client\Credentials\AccessCredentials;
 use Snaggle\Client\Credentials\ConsumerCredentials;
 


### PR DESCRIPTION
Because who doesn't like their code sniffed?

This PR

* requires `squizlabs/php_codesniffer` as a `dev` dependency
* updates `travis.yml` to run `phpcs` before running the tests
* fixes a bunch of CS issues