### PR TITLE
Fix: Class attempts to implement non-existing interface

### DIFF
--- a/src/Client/Credentials/RequestCredentials.php
+++ b/src/Client/Credentials/RequestCredentials.php
@@ -12,7 +12,7 @@ namespace Snaggle\Client\Credentials;
  * step of the token exchange. These are short-lived credentials and will
  * expire if they aren't exchanged for Access Credentials
  */
-class RequestCredentials implements Credential
+class RequestCredentials implements CredentialInterface
 {
     /**
      * The identifier for the Request Credential

--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+use Snaggle\Client\Credentials\RequestCredentials;
+
+class RequestCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanInstantiateClass()
+    {
+        new RequestCredentials();
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a failing test
* [x] makes `RequestCredential` implement the actually existing `CredentialInterface`, rather than the non-existing `Credential`