### PR TITLE
Fix: Property name spelled wrong in mutator

### DIFF
--- a/src/Client/Credentials/RequestCredentials.php
+++ b/src/Client/Credentials/RequestCredentials.php
@@ -46,7 +46,7 @@ class RequestCredentials implements CredentialInterface
      */
     public function setIdentifier($identifier)
     {
-        $this->identifer = $identifier;
+        $this->identifier = $identifier;
     }
 
     /**

--- a/src/Client/Credentials/RequestCredentials.php
+++ b/src/Client/Credentials/RequestCredentials.php
@@ -12,7 +12,7 @@ namespace Snaggle\Client\Credentials;
  * step of the token exchange. These are short-lived credentials and will
  * expire if they aren't exchanged for Access Credentials
  */
-class RequestCredentials implements Credential
+class RequestCredentials implements CredentialInterface
 {
     /**
      * The identifier for the Request Credential

--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+use Snaggle\Client\Credentials\RequestCredentials;
+
+class RequestCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanInstantiateClass()
+    {
+        new RequestCredentials();
+    }
+}

--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -27,6 +27,12 @@ class RequestCredentialsTest extends PHPUnit_Framework_TestCase
         new RequestCredentials();
     }
 
+    public function testDefaults()
+    {
+        $this->assertSame('', $this->credentials->getIdentifier());
+        $this->assertSame('', $this->credentials->getSecret());
+    }
+
     public function testCanSetAndGetIdentifier()
     {
         $identifier = 'foo';
@@ -34,5 +40,14 @@ class RequestCredentialsTest extends PHPUnit_Framework_TestCase
         $this->credentials->setIdentifier($identifier);
 
         $this->assertSame($identifier, $this->credentials->getIdentifier());
+    }
+
+    public function testCanSetAndGetSecret()
+    {
+        $secret = 'bar';
+
+        $this->credentials->setSecret($secret);
+
+        $this->assertSame($secret, $this->credentials->getSecret());
     }
 }

--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -7,8 +7,32 @@ use Snaggle\Client\Credentials\RequestCredentials;
 
 class RequestCredentialsTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var RequestCredentials
+     */
+    private $credentials;
+
+    protected function setUp()
+    {
+        $this->credentials = new RequestCredentials();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->credentials);
+    }
+
     public function testCanInstantiateClass()
     {
         new RequestCredentials();
+    }
+
+    public function testCanSetAndGetIdentifier()
+    {
+        $identifier = 'foo';
+
+        $this->credentials->setIdentifier($identifier);
+
+        $this->assertSame($identifier, $this->credentials->getIdentifier());
     }
 }


### PR DESCRIPTION
:exclamation: Blocked by #12 (branched off of `fix/interface-name`, so I can use the existing test and fixed `RequestCredentials` class, otherwise no chance of instantiating it).

This PR

* [x] provides a failing test
* [x] fixes the spelling in the mutator
* [x] adds more tests