### PR TITLE
Fix: Remove useless test

### DIFF
--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -22,11 +22,6 @@ class RequestCredentialsTest extends PHPUnit_Framework_TestCase
         unset($this->credentials);
     }
 
-    public function testCanInstantiateClass()
-    {
-        new RequestCredentials();
-    }
-
     public function testDefaults()
     {
         $this->assertSame('', $this->credentials->getIdentifier());


### PR DESCRIPTION
This PR

* [x] removes a useless test

:bulb: This method is most of the time how I start a test when I do TDD and the class doesn't even exist yet. However, as the same thing is happening in `setUp()` already, this can be removed. 