### PR TITLE
Fix: Unable to autoload TemporaryCredentials because of lack of PSR-0-compliance

### DIFF
--- a/src/Client/Credentials/TemporaryCredentials.php
+++ b/src/Client/Credentials/TemporaryCredentials.php
@@ -1,5 +1,5 @@
 <?php
-namespace Snaggle\OAuth1\Client\Credentials;
+namespace Snaggle\Client\Credentials;
 
 /**
  * @author Matt Frost <mfrost.design@gmail.com>

--- a/tests/Client/Credentials/TemporaryCredentialsTest.php
+++ b/tests/Client/Credentials/TemporaryCredentialsTest.php
@@ -8,6 +8,6 @@ class TemporaryCredentialsTest extends PHPUnit_Framework_TestCase
 {
     public function testCanAutoloadClass()
     {
-        $this->assertTrue(class_exists('Snaggle\Oauth1\Client\Credentials\TemporaryCredentials'));
+        $this->assertTrue(class_exists('Snaggle\Client\Credentials\TemporaryCredentials'));
     }
 }

--- a/tests/Client/Credentials/TemporaryCredentialsTest.php
+++ b/tests/Client/Credentials/TemporaryCredentialsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+
+class TemporaryCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanAutoloadClass()
+    {
+        $this->assertTrue(class_exists('Snaggle\Oauth1\Client\Credentials\TemporaryCredentials'));
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a failing test to show that the namespace for `TemporaryCredentials` is :hankey:'ed
* [x] fixes the namespace for `TemporaryCredentials` 

:exclamation: Blocks #17.