### PR TITLE
Enhancement: Move towards credentials as value objects

### DIFF
--- a/src/Client/Credentials/AccessCredentials.php
+++ b/src/Client/Credentials/AccessCredentials.php
@@ -37,6 +37,8 @@ class AccessCredentials implements CredentialInterface
     /**
      * Method to set the identifier
      *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
+     *
      * @param string $identifier
      */
     public function setIdentifier($identifier)
@@ -56,6 +58,8 @@ class AccessCredentials implements CredentialInterface
 
     /**
      * Method to set the secret for this identifier
+     *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
      *
      * @param string $secret
      */

--- a/src/Client/Credentials/AccessCredentials.php
+++ b/src/Client/Credentials/AccessCredentials.php
@@ -25,6 +25,16 @@ class AccessCredentials implements CredentialInterface
     private $secret;
 
     /**
+     * @param string $identifier
+     * @param string $secret
+     */
+    public function __construct($identifier = null, $secret = null)
+    {
+        $this->identifier = $identifier;
+        $this->secret = $secret;
+    }
+
+    /**
      * Method to set the identifier
      *
      * @param string $identifier

--- a/src/Client/Credentials/ConsumerCredentials.php
+++ b/src/Client/Credentials/ConsumerCredentials.php
@@ -51,6 +51,8 @@ class ConsumerCredentials implements CredentialInterface
     /**
      * Method to set the identifying property from the credential
      *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
+     *
      * @param string $identifier
      */
     public function setIdentifier($identifier)
@@ -70,6 +72,8 @@ class ConsumerCredentials implements CredentialInterface
 
     /**
      * Method to set the secret for this credential
+     *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
      *
      * @param string $secret
      */

--- a/src/Client/Credentials/ConsumerCredentials.php
+++ b/src/Client/Credentials/ConsumerCredentials.php
@@ -29,6 +29,16 @@ class ConsumerCredentials implements CredentialInterface
     private $secret = '';
 
     /**
+     * @param string $identifier
+     * @param string $secret
+     */
+    public function __construct($identifier = '', $secret = '')
+    {
+        $this->identifier = $identifier;
+        $this->secret = $secret;
+    }
+
+    /**
      * Method to retrieve the identifying property from the credential
      *
      * @return string

--- a/src/Client/Credentials/RequestCredentials.php
+++ b/src/Client/Credentials/RequestCredentials.php
@@ -52,6 +52,8 @@ class RequestCredentials implements CredentialInterface
     /**
      * Method to set the identifier for the request credential
      *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
+     *
      * @param string $identifier
      */
     public function setIdentifier($identifier)
@@ -71,6 +73,8 @@ class RequestCredentials implements CredentialInterface
 
     /**
      * Method to set the secret for the request credential
+     *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
      *
      * @param string $secret
      */

--- a/src/Client/Credentials/RequestCredentials.php
+++ b/src/Client/Credentials/RequestCredentials.php
@@ -29,6 +29,16 @@ class RequestCredentials implements CredentialInterface
     private $secret = '';
 
     /**
+     * @param string $identifier
+     * @param string $secret
+     */
+    public function __construct($identifier = '', $secret = '')
+    {
+        $this->identifier = $identifier;
+        $this->secret = $secret;
+    }
+
+    /**
      * Method to retrieve the identifier associated with the request
      * credentials
      *

--- a/src/Client/Credentials/TemporaryCredentials.php
+++ b/src/Client/Credentials/TemporaryCredentials.php
@@ -40,6 +40,8 @@ class TemporaryCredentials
     /**
      * Method to set the temporary token
      *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
+     *
      * @param string $identifier
      */
     public function setIdentifier($identifier)
@@ -59,6 +61,8 @@ class TemporaryCredentials
 
     /**
      * Method to set the verifier
+     *
+     * @deprecated Will be removed with 1.0.0, set values with constructor instead.
      *
      * @param string $verifier
      */

--- a/src/Client/Credentials/TemporaryCredentials.php
+++ b/src/Client/Credentials/TemporaryCredentials.php
@@ -28,6 +28,16 @@ class TemporaryCredentials
     private $verifier = '';
 
     /**
+     * @param string $identifier
+     * @param string $verifier
+     */
+    public function __construct($identifier = '', $verifier = '')
+    {
+        $this->identifier = $identifier;
+        $this->verifier = $verifier;
+    }
+
+    /**
      * Method to set the temporary token
      *
      * @param string $identifier

--- a/tests/Client/Credentials/AccessCredentialsTest.php
+++ b/tests/Client/Credentials/AccessCredentialsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+use Snaggle\Client\Credentials\AccessCredentials;
+
+class AccessCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AccessCredentials
+     */
+    private $credentials;
+
+    protected function setUp()
+    {
+        $this->credentials = new AccessCredentials();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->credentials);
+    }
+
+    public function testDefaults()
+    {
+        $this->assertNull($this->credentials->getIdentifier());
+        $this->assertNull($this->credentials->getSecret());
+    }
+
+    public function testCanSetAndGetIdentifier()
+    {
+        $identifier = 'foo';
+
+        $this->credentials->setIdentifier($identifier);
+
+        $this->assertSame($identifier, $this->credentials->getIdentifier());
+    }
+
+    public function testCanSetAndGetSecret()
+    {
+        $secret = 'bar';
+
+        $this->credentials->setSecret($secret);
+
+        $this->assertSame($secret, $this->credentials->getSecret());
+    }
+}

--- a/tests/Client/Credentials/AccessCredentialsTest.php
+++ b/tests/Client/Credentials/AccessCredentialsTest.php
@@ -22,6 +22,20 @@ class AccessCredentialsTest extends PHPUnit_Framework_TestCase
         unset($this->credentials);
     }
 
+    public function testConstructorSetsValues()
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $credentials = new AccessCredentials(
+            $identifier,
+            $secret
+        );
+
+        $this->assertSame($identifier, $credentials->getIdentifier());
+        $this->assertSame($secret, $credentials->getSecret());
+    }
+
     public function testDefaults()
     {
         $this->assertNull($this->credentials->getIdentifier());

--- a/tests/Client/Credentials/ConsumerCredentialsTest.php
+++ b/tests/Client/Credentials/ConsumerCredentialsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+use Snaggle\Client\Credentials\ConsumerCredentials;
+
+class ConsumerCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ConsumerCredentials
+     */
+    private $credentials;
+
+    protected function setUp()
+    {
+        $this->credentials = new ConsumerCredentials();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->credentials);
+    }
+
+    public function testDefaults()
+    {
+        $this->assertSame('', $this->credentials->getIdentifier());
+        $this->assertSame('', $this->credentials->getSecret());
+    }
+
+    public function testCanSetAndGetIdentifier()
+    {
+        $identifier = 'foo';
+
+        $this->credentials->setIdentifier($identifier);
+
+        $this->assertSame($identifier, $this->credentials->getIdentifier());
+    }
+
+    public function testCanSetAndGetSecret()
+    {
+        $secret = 'bar';
+
+        $this->credentials->setSecret($secret);
+
+        $this->assertSame($secret, $this->credentials->getSecret());
+    }
+}

--- a/tests/Client/Credentials/ConsumerCredentialsTest.php
+++ b/tests/Client/Credentials/ConsumerCredentialsTest.php
@@ -22,6 +22,21 @@ class ConsumerCredentialsTest extends PHPUnit_Framework_TestCase
         unset($this->credentials);
     }
 
+    public function testConstructorSetsValues()
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $credentials = new ConsumerCredentials(
+            $identifier,
+            $secret
+        );
+
+        $this->assertSame($identifier, $credentials->getIdentifier());
+        $this->assertSame($secret, $credentials->getSecret());
+    }
+
+
     public function testDefaults()
     {
         $this->assertSame('', $this->credentials->getIdentifier());

--- a/tests/Client/Credentials/RequestCredentialsTest.php
+++ b/tests/Client/Credentials/RequestCredentialsTest.php
@@ -22,6 +22,20 @@ class RequestCredentialsTest extends PHPUnit_Framework_TestCase
         unset($this->credentials);
     }
 
+    public function testConstructorSetsValues()
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $credentials = new RequestCredentials(
+            $identifier,
+            $secret
+        );
+
+        $this->assertSame($identifier, $credentials->getIdentifier());
+        $this->assertSame($secret, $credentials->getSecret());
+    }
+
     public function testDefaults()
     {
         $this->assertSame('', $this->credentials->getIdentifier());

--- a/tests/Client/Credentials/TemporaryCredentialsTest.php
+++ b/tests/Client/Credentials/TemporaryCredentialsTest.php
@@ -19,6 +19,20 @@ class TemporaryCredentialsTest extends PHPUnit_Framework_TestCase
         $this->credentials = new TemporaryCredentials();
     }
 
+    public function testConstructorSetsValues()
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $credentials = new TemporaryCredentials(
+            $identifier,
+            $secret
+        );
+
+        $this->assertSame($identifier, $credentials->getIdentifier());
+        $this->assertSame($secret, $credentials->getVerifier());
+    }
+
     protected function tearDown()
     {
         unset($this->credentials);

--- a/tests/Client/Credentials/TemporaryCredentialsTest.php
+++ b/tests/Client/Credentials/TemporaryCredentialsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Snaggle\Tests\Client\Credentials;
+
+use PHPUnit_Framework_TestCase;
+use Snaggle\OAuth1\Client\Credentials\TemporaryCredentials;
+
+require_once __DIR__ . '/../../../src/Client/Credentials/TemporaryCredentials.php';
+
+class TemporaryCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TemporaryCredentials
+     */
+    private $credentials;
+
+    protected function setUp()
+    {
+        $this->credentials = new TemporaryCredentials();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->credentials);
+    }
+
+    public function testDefaults()
+    {
+        $this->assertSame('', $this->credentials->getIdentifier());
+    }
+
+    public function testCanSetAndGetIdentifier()
+    {
+        $identifier = 'foo';
+
+        $this->credentials->setIdentifier($identifier);
+
+        $this->assertSame($identifier, $this->credentials->getIdentifier());
+    }
+
+    public function testCanSetAndGetVerifier()
+    {
+        $verifier = 'bar';
+
+        $this->credentials->setVerifier($verifier);
+
+        $this->assertSame($verifier, $this->credentials->getVerifier());
+    }
+}


### PR DESCRIPTION
Relates to #14.

This PR

* [x] adds tests to prevent regressions in existing functionality
* [x] adds constructors allowing to inject values
* [x] deprecates mutators (informs when they will be removed and to use constructor instead)

:exclamation: Blocked by #16.