### PR TITLE
Fix: Default to empty string

### DIFF
--- a/src/Client/Credentials/AccessCredentials.php
+++ b/src/Client/Credentials/AccessCredentials.php
@@ -17,18 +17,18 @@ class AccessCredentials implements CredentialInterface
     /**
      * Property for the identifying token
      */
-    private $identifier;
+    private $identifier = '';
 
     /**
      * Property for the secret
      */
-    private $secret;
+    private $secret = '';
 
     /**
      * @param string $identifier
      * @param string $secret
      */
-    public function __construct($identifier = null, $secret = null)
+    public function __construct($identifier = '', $secret = '')
     {
         $this->identifier = $identifier;
         $this->secret = $secret;

--- a/tests/Client/Credentials/AccessCredentialsTest.php
+++ b/tests/Client/Credentials/AccessCredentialsTest.php
@@ -38,8 +38,8 @@ class AccessCredentialsTest extends PHPUnit_Framework_TestCase
 
     public function testDefaults()
     {
-        $this->assertNull($this->credentials->getIdentifier());
-        $this->assertNull($this->credentials->getSecret());
+        $this->assertSame('', $this->credentials->getIdentifier());
+        $this->assertSame('', $this->credentials->getSecret());
     }
 
     public function testCanSetAndGetIdentifier()


### PR DESCRIPTION
Because that's the case for all of the other implementations of `CredentialInterface`.