### PR TITLE
Empty oauth_token params

### DIFF
--- a/src/Client/Header/Header.php
+++ b/src/Client/Header/Header.php
@@ -44,7 +44,11 @@ class Header
         if (($verifier = $this->signature->getVerifier()) !== '') {
             $headerParams['oauth_verifier'] = $verifier;
         }
-
+        
+        if ($headerParams['oauth_token'] === '') {
+            unset($headerParams['oauth_token']);
+        }
+        
         $tempArray = array();
         ksort($headerParams);
 

--- a/src/Client/Signatures/HmacSha1.php
+++ b/src/Client/Signatures/HmacSha1.php
@@ -69,6 +69,10 @@ class HmacSha1 extends Signature implements SignatureInterface
             unset($oauthParams['oauth_verifier']);
         }
 
+        if ($oauthParams['oauth_token'] === '') {
+            unset($oauthParams['oauth_token']);
+        }
+        
         array_walk($oauthParams, function($value, $key) use (&$tempArray) {
             $tempArray[] = $key . '=' . rawurlencode($value);
         });


### PR DESCRIPTION
I'm trying to adapt this to usage with Intuit QB and it kept failing because the oauth_token was getting set for the token request, even though it was blank. Once I hardcoded it out, problem went away. So I thought it would be good to remove oauth_token if it's blank. Eh?
